### PR TITLE
Cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.o
+*.so
+moc_*
+Makefile

--- a/customcontext/context.cpp
+++ b/customcontext/context.cpp
@@ -265,21 +265,20 @@ void Context::renderContextInitialized(QSGRenderContext *ctx)
     CONTEXT_CLASS_BASE::renderContextInitialized(ctx);
 }
 
-
-
-
-
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
 void RenderContext::initialize(const InitParams *inCtx)
 {
+    // FIXME: missing context variable here?
 #elif QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
 void RenderContext::initialize(void *inCtx)
 {
     QOpenGLContext *context = static_cast<QOpenGLContext*>(inCtx);
+    Q_UNUSED(context); // avoid warnings
 #else
 void RenderContext::initialize(QOpenGLContext *inCtx)
 {
     QOpenGLContext *context = inCtx;
+    Q_UNUSED(context); // avoid warnings
 #endif
 
 #ifdef CUSTOMCONTEXT_DITHER

--- a/rpm/qtscenegraph-adaptation-droid.spec
+++ b/rpm/qtscenegraph-adaptation-droid.spec
@@ -1,9 +1,9 @@
 Name:       qtscenegraph-adaptation
 Summary:    Scenegraph adaptation for Droid
-Version:    git
-Release:    1%{?dist}
+Version:    0.8.1
+Release:    1
 License:    LGPLv2 with exception or GPLv3 or Qt Commercial
-URL:        https://git.sailfishos.org/mer-core/qtscenegraph-adaptation
+URL:        https://github.com/sailfishos/qtscenegraph-adaptation
 Source0:    %{name}-%{version}.tar.bz2
 BuildRequires:  qt5-qtcore-devel
 BuildRequires:  qt5-qtgui-devel
@@ -15,8 +15,6 @@ BuildRequires:  qt5-qmake
 This package contains system specific changes for the
 Qt Quick Scene Graph.
 
-#### Build section
-
 %prep
 %setup -q -n %{name}-%{version}
 
@@ -25,26 +23,13 @@ export QTDIR=/usr/share/qt5
 %qmake5 -config "surfaceformat programbinary hybristexture" DEFINES+=EGL_NO_X11
 
 %install
-rm -rf %{buildroot}
 %qmake5_install
 
-#### Pre/Post section
+%post -p /sbin/ldconfig
+%postun -p /sbin/ldconfig
 
-%post
-/sbin/ldconfig
-%postun
-/sbin/ldconfig
-
-
-
-
-#### File section
 %files
-%defattr(-,root,root,-)
 %license LICENSE.LGPL
 %license LGPL_EXCEPTION.txt
 %license LICENSE.GPL
 %{_libdir}/qt5/plugins/scenegraph/libcustomcontext.so
-
-
-#### No changelog section, separate $pkg.changelog contains the history


### PR DESCRIPTION
Noticed qt >=5.14 is missing a context variable, but not sure how much there is need for the #ifdeffed optional content that use it.